### PR TITLE
Refine Dietz molecule validation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ module Main where
 
 import Chem.IO.SDF (readSDF)
 import Chem.Molecule (prettyPrintMolecule)
-import Chem.Validate (validateMolecule, ValidationWarning(..))
+import Chem.Validate (validateMolecule)
 import LogPModel (LogPInferenceMethod(..), runLogPRegressionWith)
 import Text.Megaparsec (errorBundlePretty)
 import Text.Read (readMaybe)
@@ -39,11 +39,10 @@ main = do
     Left err -> putStrLn (errorBundlePretty err)
     Right benzene ->
       case validateMolecule benzene of
-        Left errs -> do
+        Left err -> do
           putStrLn "Benzene invalid:"
-          mapM_ (putStrLn . show) errs
-        Right (_, warns) -> do
-          mapM_ (putStrLn . ("Warning: " ++) . show) warns
+          putStrLn err
+        Right _ -> do
           putStrLn (prettyPrintMolecule benzene)
           benzeneActualLogP <- readSDFDoubleProperty "molecules/benzene.sdf" "PUBCHEM_XLOGP3"
           case benzeneActualLogP of
@@ -57,9 +56,9 @@ main = do
             Left err -> putStrLn (errorBundlePretty err)
             Right water ->
               case validateMolecule water of
-                Left errs2 -> do
+                Left err2 -> do
                   putStrLn "Water invalid:"
-                  mapM_ (putStrLn . show) errs2
+                  putStrLn err2
                 Right _ -> do
                   putStrLn "Running LogP regression over DB1 and predicting for water and DB2 (LWIS):"
                   let trackedMolecules =

--- a/examples/ParseMolecules.hs
+++ b/examples/ParseMolecules.hs
@@ -7,7 +7,7 @@ import Chem.IO.SDF (readSDF)
 import Chem.Molecule (prettyPrintMolecule)
 import Chem.Dietz ()
 import Text.Megaparsec (errorBundlePretty)
-import Chem.Validate (validateMolecule, ValidationWarning(..))
+import Chem.Validate (validateMolecule)
 
 -- | Parse and validate the provided benzene and water SDF files, printing any
 -- warnings emitted by the validator before rendering the molecules.
@@ -19,11 +19,10 @@ main = do
         Left err -> putStrLn $ errorBundlePretty err
         Right mol ->
           case validateMolecule mol of
-            Left errs -> do
+            Left err -> do
               putStrLn "Benzene invalid:"
-              mapM_ (putStrLn . show) errs
-            Right (_, warns) -> do
-              mapM_ (putStrLn . ("Warning: " ++) . show) warns
+              putStrLn err
+            Right _ ->
               putStrLn $ prettyPrintMolecule mol
 
     putStrLn "\nParsing water.sdf"
@@ -32,9 +31,8 @@ main = do
         Left err -> putStrLn $ errorBundlePretty err
         Right mol ->
           case validateMolecule mol of
-            Left errs -> do
+            Left err -> do
               putStrLn "Water invalid:"
-              mapM_ (putStrLn . show) errs
-            Right (_, warns) -> do
-              mapM_ (putStrLn . ("Warning: " ++) . show) warns
+              putStrLn err
+            Right _ ->
               putStrLn $ prettyPrintMolecule mol

--- a/src/Chem/Validate.hs
+++ b/src/Chem/Validate.hs
@@ -1,32 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Validation routines for Dietz-based molecules.  The checks are split
--- into hard errors (structural inconsistencies) and soft warnings (heuristic
--- electron counting) so that callers can decide how strict to be.
+-- | Validation routines for Dietz-based molecules.  The validator enforces
+-- structural invariants (existing atoms, symmetric bond maps, reasonable
+-- valence counts) and returns the molecule unchanged on success.
 module Chem.Validate
-  ( ValidationError(..)
-  , ValidationWarning(..)
-  , validateMolecule
+  ( validateMolecule
   , usedElectronsAt
   ) where
 
 import           Chem.Molecule
 import           Chem.Dietz
-import           Constants (nominalValence)
+import           Constants (getMaxBondsSymbol)
 import qualified Data.Map.Strict as M
 import qualified Data.Set        as S
-
--- | Specific validation errors.
-data ValidationError
-  = SelfBond Edge                    -- ^ bond from an atom to itself
-  | MissingAtom Edge AtomId          -- ^ bond references a missing atom
-  | SystemMissingAtom SystemId Edge  -- ^ system references a missing atom
-  deriving (Eq, Show)
-
--- | Non-fatal validation warnings.
-data ValidationWarning
-  = ElectronLimitExceeded AtomId Double Double -- ^ actual vs allowed electrons
-  deriving (Eq, Show)
+import           Control.Monad   (foldM)
 
 -- | Total electrons used at an atom, combining σ bonds and Dietz pools.
 -- Uses the Dietz pool formula: e_S(v) = s * deg_S(v) / (2*|E_S|).
@@ -46,41 +33,93 @@ usedElectronsAt m v = sigma + system
           totalEdges = fromIntegral (S.size (memberEdges bs))
       in if totalEdges == 0 then 0 else s * degSv / (2 * totalEdges)
 
+type BondMap = M.Map (AtomId, AtomId) Double
+
 -- | Validate a molecule according to Dietz bonding rules.
-validateMolecule :: Molecule -> Either [ValidationError] (Molecule, [ValidationWarning])
-validateMolecule m =
-  case errs of
-    [] -> Right (m, warnings)
-    _  -> Left errs
+validateMolecule :: Molecule -> Either String Molecule
+validateMolecule m = do
+  let atomIDsList = M.keys (atoms m)
+      atomSet     = S.fromList atomIDsList
+
+  sigmaMap <- foldM (accumulateBond atomSet 2.0) M.empty (S.toList (localBonds m))
+  let addSystem acc (_, bs) = addSystemBonds atomSet bs acc
+  fullMap <- foldM addSystem sigmaMap (systems m)
+  ensureSymmetric fullMap
+  ensureValence m atomSet fullMap
+  pure m
+
+-- | Insert a bond contribution into the directed bond map, performing the
+-- endpoint and self-bond checks mandated by the validator specification.
+accumulateBond :: S.Set AtomId -> Double -> BondMap -> Edge -> Either String BondMap
+accumulateBond atomSet value acc (Edge i j)
+  | i == j = Left $ "Atom " ++ showAtomId i ++ " is bonded to itself"
+  | not (i `S.member` atomSet) || not (j `S.member` atomSet)
+      = Left "Bond references non-existent atom"
+  | otherwise = Right $ addDirected i j value (addDirected j i value acc)
   where
-    atomSet = M.keysSet (atoms m)
+    showAtomId (AtomId n) = show n
 
-    -- Check each sigma bond.
-    sigmaErrs = concat
-      [ checkEdge e
-      | e@(Edge i j) <- S.toList (localBonds m) ]
-    checkEdge e@(Edge i j)
-      | i == j = [SelfBond e]
-      | not (i `S.member` atomSet) = [MissingAtom e i]
-      | not (j `S.member` atomSet) = [MissingAtom e j]
-      | otherwise = []
+-- | Accumulate contributions from a Dietz bonding system by distributing the
+-- shared electrons across its member edges.
+addSystemBonds :: S.Set AtomId -> BondingSystem -> BondMap -> Either String BondMap
+addSystemBonds atomSet bs acc
+  | edgeCount == 0 = Right acc
+  | otherwise      = foldM insertEdge acc (S.toList (memberEdges bs))
+  where
+    edgeCount = S.size (memberEdges bs)
+    contribution = fromIntegral (getNN (sharedElectrons bs))
+                 / fromIntegral edgeCount
 
-    -- Check bonding systems for nonexistent atoms.
-    systemErrs =
-      [ SystemMissingAtom sid e
-      | (sid, bs) <- systems m
-      , e@(Edge i j) <- S.toList (memberEdges bs)
-      , not (i `S.member` atomSet) || not (j `S.member` atomSet)
-      ]
+    insertEdge m (Edge i j)
+      | i == j = Left $ "Atom " ++ showAtomId i ++ " is bonded to itself"
+      | not (i `S.member` atomSet) || not (j `S.member` atomSet)
+          = Left "Bond references non-existent atom"
+      | otherwise = Right $ addDirected i j contribution (addDirected j i contribution m)
 
-    -- Electron accounting per atom.
-    electronWarnings =
-      [ ElectronLimitExceeded i count limit
-      | (i, atom) <- M.toList (atoms m)
-      , let count = usedElectronsAt m i
-            limit = fromIntegral (snd (nominalValence (symbol (attributes atom))))
-      , count > limit
-      ]
+    showAtomId (AtomId n) = show n
 
-    errs = sigmaErrs ++ systemErrs
-    warnings = electronWarnings
+-- | Ensure that for every directed bond entry (i,j) there exists a mirrored
+-- entry (j,i) with the same contribution.
+ensureSymmetric :: BondMap -> Either String ()
+ensureSymmetric bonds = foldM check () (M.toList bonds)
+  where
+    check _ ((i,j), val) =
+      case M.lookup (j,i) bonds of
+        Nothing   -> Left "Bond map is not symmetric"
+        Just val' ->
+          if approxEqual val val'
+            then Right ()
+            else Left "Bond map is not symmetric"
+
+-- | Verify that each atom respects its maximum valence according to the
+-- element-specific bound.
+ensureValence :: Molecule -> S.Set AtomId -> BondMap -> Either String ()
+ensureValence mol atomSet bonds =
+  foldM check () (S.toList atomSet)
+  where
+    atomMap = atoms mol
+    contributions i =
+      [ val
+      | ((a,_), val) <- M.toList bonds
+      , a == i ]
+
+    check _ aid =
+      case M.lookup aid atomMap of
+        Nothing -> Left "Bond references non-existent atom"
+        Just atom ->
+          let total    = sum (contributions aid)
+              used     = total / 2.0
+              maxVal   = getMaxBondsSymbol (symbol (attributes atom))
+          in if used <= maxVal + 1e-9
+                then Right ()
+                else Left $ "Atom " ++ showAtomId aid ++ " exceeds maximum valence"
+
+    showAtomId (AtomId n) = show n
+
+-- | Insert a directed bond contribution, summing if an entry already exists.
+addDirected :: AtomId -> AtomId -> Double -> BondMap -> BondMap
+addDirected i j value = M.insertWith (+) (i, j) value
+
+-- | Approximate equality used when comparing symmetric bond contributions.
+approxEqual :: Double -> Double -> Bool
+approxEqual a b = abs (a - b) <= 1e-9

--- a/src/Constants.hs
+++ b/src/Constants.hs
@@ -121,6 +121,13 @@ nominalValence symbol = case symbol of
     I  -> (2, 2)
     Na -> (2, 2)
 
+-- | Maximum number of bonds typically formed by an element, derived from the
+-- upper electron count in 'nominalValence'.
+getMaxBondsSymbol :: AtomicSymbol -> Double
+getMaxBondsSymbol sym =
+    let (_, maxElectrons) = nominalValence sym
+    in fromIntegral maxElectrons / 2.0
+
 -- | Tabulate atomic numbers and atomic weights for the supported elements.
 elementAttributes O = ElementAttributes O 8 15.999
 elementAttributes H = ElementAttributes H 1 1.008


### PR DESCRIPTION
## Summary
- rewrite the Dietz validator to accumulate symmetric bond contributions and enforce valence limits
- add a maximum-bond helper derived from nominal valence and remove warning plumbing from callers
- update the CLI demo and parsing example to reflect the simplified validation result

## Testing
- Not run (stack unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3b801e69c8330bce0a2c629fc9f81