### PR TITLE
Restrict open modules and document binary distribution workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ./.DS_Store
 dist-newstyle/
 .stack-work/*
+closed-bin/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Sample SDF files for these experiments are provided in `molecules/` and `logp/`.
 
 An example Haskell representation of a molecule is available in `src/Benzene.hs`, which defines the `benzene` structure programmatically.
 
+## Open vs. closed components
+
+Only the `Constants`, `LogPModel`, and `PrettyBenzene` modules are now exposed
+in the public library interface.  All other modules are treated as internal
+dependencies that can be compiled and distributed separately as proprietary
+artifacts.  See [`docs/binary-packaging.md`](docs/binary-packaging.md) for a
+step-by-step guide to producing those binaries and linking them with the open
+modules when preparing a release.
+
 ## Array backend
 
 The logP regression pipeline now relies on the [`massiv`](https://hackage.haskell.org/package/massiv) array library for parallel-friendly map and fold operations. No manual flags are required—running `stack build` will automatically pull in the Massiv dependency declared in `package.yaml`.

--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -20,15 +20,22 @@ extra-source-files:
 
 library
     exposed-modules:
+        Constants
+        LogPModel
+        PrettyBenzene
+    other-modules:
+        Benzene
         Chem.Dietz
         Chem.IO.SDF
         Chem.Molecule
+        Chem.Molecule.Coordinate
         Chem.Validate
-        Constants
         Distr
+        EffectfulCode.Python.Analyse.WalkTree
+        EffectfulCode.Python.Analyse.WalkTree.Compat
+        ExtraF
         Group
         LazyPPL
-        LogPModel
         MolADT
         MolADT.LogP
         MolADT.Molecule
@@ -41,11 +48,6 @@ library
         SampleMolecules
         Serialisable
         SlaterTypeOrbital
-        Benzene
-        BenzenePretty
-    other-modules:
-        ExtraF
-        Chem.Molecule.Coordinate
     hs-source-dirs:
         src
     default-language: Haskell2010

--- a/docs/binary-packaging.md
+++ b/docs/binary-packaging.md
@@ -1,0 +1,95 @@
+# Binary Packaging Guide
+
+This repository now treats `Constants`, `LogPModel`, and `PrettyBenzene` as the
+open components that depend on a privately distributed binary providing the
+core molecule representations and algorithms.  The steps below outline how to
+produce shipping artifacts once the proprietary library is available.
+
+## 1. Build the proprietary core
+
+1. Clone the private repository containing the closed modules (everything under
+   `src/` except the three open modules) and build it as a Cabal library:
+
+   ```bash
+   cabal build lib:chemalgprog-internal
+   ```
+
+2. After the build completes, copy the resulting interface (`.hi`) files and
+   static archive (`.a`) into this repository under `closed-bin/`.  The build
+   products live under `dist-newstyle/build/<platform>/ghc-<version>/chemalgprog-internal-*/build`.
+
+   ```bash
+   mkdir -p closed-bin
+   cp dist-newstyle/build/*/ghc-*/chemalgprog-internal-*/build/*.hi closed-bin/
+   cp dist-newstyle/build/*/ghc-*/chemalgprog-internal-*/build/libHSchemalgprog-internal-*.a closed-bin/
+   ```
+
+3. When using Stack, create a static library by running:
+
+   ```bash
+   stack build --flag chemalgprog-internal:static
+   stack ls dependencies | grep chemalgprog-internal
+   cp $(stack path --local-install-root)/lib/libHSchemalgprog-internal-*.a closed-bin/
+   ```
+
+   The Stack invocation assumes the private package defines a `static` flag to
+   request static archives.
+
+## 2. Link the open components against the binary
+
+With the closed binary copied into `closed-bin/`, adjust `extra-lib-dirs` and
+`include-dirs` in the private build plan or pass them to Cabal directly:
+
+```bash
+cabal build lib:chemalgprog \
+  --extra-lib-dirs="$(pwd)/closed-bin" \
+  --extra-include-dirs="$(pwd)/closed-bin"
+```
+
+For Stack, the same paths can be exported via environment variables prior to
+invocation:
+
+```bash
+export LIBRARY_PATH="$(pwd)/closed-bin:${LIBRARY_PATH}"
+export C_INCLUDE_PATH="$(pwd)/closed-bin:${C_INCLUDE_PATH}"
+stack build
+```
+
+## 3. Ship the executables as binaries
+
+Once the open library resolves against the proprietary archive you can produce
+redistributable executables.
+
+### Cabal
+
+```bash
+cabal build exe:chemalgprog exe:parse-molecules exe:serialize-molecule
+cabal install exe:chemalgprog exe:parse-molecules exe:serialize-molecule \
+  --installdir="$(pwd)/dist/bin" \
+  --overwrite-policy=always
+```
+
+The resulting binaries are placed under `dist/bin/` and can be zipped or
+packaged for distribution.
+
+### Stack
+
+```bash
+stack build
+stack install --local-bin-path "$(pwd)/dist/bin"
+```
+
+Both commands rely on the local binary cache; the second copies the executables
+into `dist/bin/` for shipping.
+
+## 4. Optional stripping and verification
+
+To reduce binary sizes and verify linkage:
+
+```bash
+strip dist/bin/chemalgprog dist/bin/parse-molecules dist/bin/serialize-molecule
+ldd dist/bin/chemalgprog
+```
+
+These steps help ensure the final deliverables ship only with the required
+open-source surface while all sensitive logic remains in the proprietary build.

--- a/package.yaml
+++ b/package.yaml
@@ -35,31 +35,34 @@ dependencies:
 library:
   source-dirs: src
   exposed-modules:
-    - MolADT
-    - MolADT.Parse
-    - MolADT.Molecule
-    - MolADT.Validate
-    - MolADT.LogP
-    - MolADT.Serialization
-    - MolADT.Samples
-    - Chem.Dietz
-    - Chem.Molecule
-    - Chem.Validate
-    - LazyPPL
     - Constants
-    - Distr
-    - Group
-    - Orbital
-    - SlaterTypeOrbital
-    - Chem.IO.SDF
-    - Reaction
-    - Serialisable
-    - SampleMolecules
-    - Benzene
     - LogPModel
+    - PrettyBenzene
   other-modules:
-    - ExtraF
+    - Benzene
+    - Chem.Dietz
+    - Chem.IO.SDF
+    - Chem.Molecule
     - Chem.Molecule.Coordinate
+    - Chem.Validate
+    - Distr
+    - EffectfulCode.Python.Analyse.WalkTree
+    - EffectfulCode.Python.Analyse.WalkTree.Compat
+    - ExtraF
+    - Group
+    - LazyPPL
+    - MolADT
+    - MolADT.LogP
+    - MolADT.Molecule
+    - MolADT.Parse
+    - MolADT.Samples
+    - MolADT.Serialization
+    - MolADT.Validate
+    - Orbital
+    - Reaction
+    - SampleMolecules
+    - Serialisable
+    - SlaterTypeOrbital
   language: Haskell2010
 
 executables:

--- a/src/Benzene.hs
+++ b/src/Benzene.hs
@@ -14,7 +14,7 @@ import Chem.Dietz
 import Constants (elementAttributes, elementShells)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import BenzenePretty (benzenePretty)
+import PrettyBenzene (benzenePretty)
 
 -- | Canonical benzene example consisting of six carbons and six hydrogens.
 -- The ring carbons form both a sigma cycle and a delocalised \(\pi\)-system.

--- a/src/PrettyBenzene.hs
+++ b/src/PrettyBenzene.hs
@@ -1,4 +1,4 @@
-module BenzenePretty (benzenePretty) where
+module PrettyBenzene (benzenePretty) where
 
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S


### PR DESCRIPTION
## Summary
- narrow the library surface to expose only Constants, LogPModel, and PrettyBenzene
- rename the benzene helper module to PrettyBenzene and update configuration to treat other modules as internal
- add binary packaging documentation and ignore the closed-bin/ drop location for proprietary artifacts

## Testing
- not run (stack/cabal unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68edd69537ec833093419749202fa1f5