### PR TITLE
Enable NamedFieldPuns in LogPModel

### DIFF
--- a/src/LogPModel.hs
+++ b/src/LogPModel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 -- | Probabilistic regression model that learns quantitative structure-property
 -- relationships (logP) from SDF datasets.  The module contains both feature
 -- extraction helpers and the inference driver used by the executable demo.


### PR DESCRIPTION
## Summary
- enable the NamedFieldPuns language extension in LogPModel to allow field punning syntax

## Testing
- not run (stack is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68ee4b71dc7483309673264e43414498