### PR TITLE
Rename main executable to moladtbayes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a datatype for molecules, complete with orbitals, reaction dynamics and 
 2. **Run the demonstration program**
 
    ```bash
-   stack exec chemalgprog
+   stack exec moladtbayes
    ```
 
    This executable:
@@ -51,6 +51,6 @@ The probabilistic programming components (`LazyPPL.hs` and `Distr.hs`) are taken
 
 ## What the Program Does
 
-The `chemalgprog` executable parses the sample benzene molecule (`molecules/benzene.sdf`) to showcase structural validation, then loads `molecules/water.sdf` as the test molecule for the regression. Coefficients are inferred from the training set `logp/DB1.sdf`, the logP of water is predicted from these coefficients, and predicted versus observed values for all molecules in `logp/DB2.sdf` are printed. The `parse-molecules` example demonstrates parsing and validating multiple SDF files.
+The `moladtbayes` executable parses the sample benzene molecule (`molecules/benzene.sdf`) to showcase structural validation, then loads `molecules/water.sdf` as the test molecule for the regression. Coefficients are inferred from the training set `logp/DB1.sdf`, the logP of water is predicted from these coefficients, and predicted versus observed values for all molecules in `logp/DB2.sdf` are printed. The `parse-molecules` example demonstrates parsing and validating multiple SDF files.
 
 

--- a/chemalgprog.cabal
+++ b/chemalgprog.cabal
@@ -64,7 +64,7 @@ library
         transformers,
         vector
 
-executable chemalgprog
+executable moladtbayes
     main-is: Main.hs
     other-modules:
         Paths_chemalgprog

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,7 @@ library:
   language: Haskell2010
 
 executables:
-  chemalgprog:
+  moladtbayes:
     main: Main.hs
     source-dirs: app
     dependencies:

--- a/src/LogPModel.hs
+++ b/src/LogPModel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 -- | Probabilistic regression model that learns quantitative structure-property
 -- relationships (logP) from SDF datasets.  The module contains both feature
 -- extraction helpers and the inference driver used by the executable demo.


### PR DESCRIPTION
## Summary
- rename the primary executable target from `chemalgprog` to `moladtbayes` in the Cabal and hpack metadata
- update the README to reference the new executable name in usage instructions

## Testing
- not run (stack unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ee4b71dc7483309673264e43414498