### PR TITLE
Add combustion instruction example

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,6 +6,7 @@ module Main where
 import Chem.IO.SDF (readSDF)
 import Chem.Molecule (prettyPrintMolecule)
 import Chem.Validate (validateMolecule)
+import InstructionsForBlockchain.Minimal (runMinimalDemo)
 import LogPModel (LogPInferenceMethod(..), runLogPRegressionWith)
 import Text.Megaparsec (errorBundlePretty)
 import Text.Read (readMaybe)
@@ -70,3 +71,5 @@ main = do
                   runLogPRegressionWith lwisMethod trackedMolecules
                   putStrLn "Running LogP regression over DB1 and predicting for water and DB2 (MH):"
                   runLogPRegressionWith mhMethod trackedMolecules
+                  putStrLn ""
+                  runMinimalDemo

--- a/moladtbayes.cabal
+++ b/moladtbayes.cabal
@@ -37,6 +37,11 @@ library
         BenzenePretty
         PrettyBenzene
         LogPModel
+        InstructionsForBlockchain
+        InstructionsForBlockchain.Hash
+        InstructionsForBlockchain.MoleculeBlueprint
+        InstructionsForBlockchain.ChemputerProgram
+        InstructionsForBlockchain.Example
     other-modules:
         ExtraF
         Chem.Molecule.Coordinate

--- a/moladtbayes.cabal
+++ b/moladtbayes.cabal
@@ -42,6 +42,7 @@ library
         InstructionsForBlockchain.MoleculeBlueprint
         InstructionsForBlockchain.ChemputerProgram
         InstructionsForBlockchain.Example
+        InstructionsForBlockchain.Minimal
     other-modules:
         ExtraF
         Chem.Molecule.Coordinate

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,11 @@ library:
     - BenzenePretty
     - PrettyBenzene
     - LogPModel
+    - InstructionsForBlockchain
+    - InstructionsForBlockchain.Hash
+    - InstructionsForBlockchain.MoleculeBlueprint
+    - InstructionsForBlockchain.ChemputerProgram
+    - InstructionsForBlockchain.Example
   other-modules:
     - ExtraF
     - Chem.Molecule.Coordinate

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
     - InstructionsForBlockchain.MoleculeBlueprint
     - InstructionsForBlockchain.ChemputerProgram
     - InstructionsForBlockchain.Example
+    - InstructionsForBlockchain.Minimal
   other-modules:
     - ExtraF
     - Chem.Molecule.Coordinate

--- a/src/InstructionsForBlockchain.hs
+++ b/src/InstructionsForBlockchain.hs
@@ -4,9 +4,11 @@ module InstructionsForBlockchain
   , module InstructionsForBlockchain.MoleculeBlueprint
   , module InstructionsForBlockchain.ChemputerProgram
   , module InstructionsForBlockchain.Example
+  , module InstructionsForBlockchain.Minimal
   ) where
 
 import InstructionsForBlockchain.Hash
 import InstructionsForBlockchain.MoleculeBlueprint
 import InstructionsForBlockchain.ChemputerProgram
 import InstructionsForBlockchain.Example
+import InstructionsForBlockchain.Minimal

--- a/src/InstructionsForBlockchain.hs
+++ b/src/InstructionsForBlockchain.hs
@@ -1,0 +1,12 @@
+-- | High-level entry point re-exporting the blockchain instruction helpers.
+module InstructionsForBlockchain
+  ( module InstructionsForBlockchain.Hash
+  , module InstructionsForBlockchain.MoleculeBlueprint
+  , module InstructionsForBlockchain.ChemputerProgram
+  , module InstructionsForBlockchain.Example
+  ) where
+
+import InstructionsForBlockchain.Hash
+import InstructionsForBlockchain.MoleculeBlueprint
+import InstructionsForBlockchain.ChemputerProgram
+import InstructionsForBlockchain.Example

--- a/src/InstructionsForBlockchain/ChemputerProgram.hs
+++ b/src/InstructionsForBlockchain/ChemputerProgram.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- | Monadic scripting layer that turns molecules and reactions into
+-- blockchain-friendly chemputer instructions.
+module InstructionsForBlockchain.ChemputerProgram
+  ( ChemputerProgram(..)
+  , Instruction(..)
+  , Operation(..)
+  , InstructionMetadata(..)
+  , ProvenanceTag(..)
+  , ChemputerM
+  , runChemputerProgram
+  , emptyMetadata
+  , withProvenance
+  , withNotes
+  , registerBlueprint
+  , verifyBlueprint
+  , dose
+  , adjustTemperature
+  , adjustPressure
+  , holdForRate
+  , recordProduct
+  , emitNote
+  , compileReaction
+  ) where
+
+import           Chem.Molecule (Molecule)
+import           Control.Monad (forM_)
+import           Control.Monad.State.Strict (State, get, put, runState)
+import qualified Data.ByteString.Builder as BB
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           Data.Word (Word64)
+
+import           InstructionsForBlockchain.Hash (hashBuilder)
+import           InstructionsForBlockchain.MoleculeBlueprint
+
+import           Reaction (Condition(..), Reaction(..))
+
+-- | Opaque wrapper produced once a script has been assembled.
+data ChemputerProgram a = ChemputerProgram
+  { programInstructions :: [Instruction]
+  , programResult       :: a
+  } deriving (Eq, Show)
+
+-- | Individual instruction enriched with metadata for auditing.
+data Instruction = Instruction
+  { instructionIndex :: Int
+  , instructionOp    :: Operation
+  , instructionMeta  :: InstructionMetadata
+  } deriving (Eq, Show)
+
+-- | Primitive operations understood by the hypothetical chemputer.
+data Operation
+  = RegisterBlueprint MoleculeBlueprint
+  | VerifyMolecule MoleculeBlueprint VerificationChecklist
+  | Dose MoleculeBlueprint Double
+  | AdjustTemperature Double
+  | AdjustPressure Double
+  | HoldForRate Double
+  | RecordProduct MoleculeBlueprint Double
+  | EmitNote Text
+  deriving (Eq, Show)
+
+-- | Additional contextual metadata emitted with each instruction.
+data InstructionMetadata = InstructionMetadata
+  { metadataProvenance :: [ProvenanceTag]
+  , metadataNotes      :: [Text]
+  } deriving (Eq, Show)
+
+-- | Provenance annotations attach hashes or external references to steps.
+data ProvenanceTag
+  = MoleculeTag Text Word64
+  | ReactionTag Text Word64
+  | ExternalReference Text
+  deriving (Eq, Show)
+
+-- | Internal state used when assembling a program.
+data ChemputerState = ChemputerState
+  { nextIndex     :: !Int
+  , instructionsR :: ![Instruction]
+  }
+
+newtype ChemputerM a = ChemputerM { unChemputerM :: State ChemputerState a }
+  deriving (Functor, Applicative, Monad)
+
+-- | Execute a chemputer program, returning the emitted instructions and the
+-- result value produced by the monadic script.
+runChemputerProgram :: ChemputerM a -> ChemputerProgram a
+runChemputerProgram (ChemputerM action) =
+  let initialState = ChemputerState 0 []
+      (result, finalState) = runState action initialState
+  in ChemputerProgram (reverse (instructionsR finalState)) result
+
+-- | Empty metadata helper.
+emptyMetadata :: InstructionMetadata
+emptyMetadata = InstructionMetadata [] []
+
+-- | Append provenance tags to metadata.
+withProvenance :: [ProvenanceTag] -> InstructionMetadata -> InstructionMetadata
+withProvenance tags meta = meta { metadataProvenance = metadataProvenance meta ++ tags }
+
+-- | Append free-form notes to metadata.
+withNotes :: [Text] -> InstructionMetadata -> InstructionMetadata
+withNotes notes meta = meta { metadataNotes = metadataNotes meta ++ notes }
+
+-- | Internal helper that pushes a new instruction onto the state.
+emit :: Operation -> InstructionMetadata -> ChemputerM ()
+emit op meta = ChemputerM $ do
+  ChemputerState idx acc <- get
+  let instr = Instruction idx op meta
+  put $ ChemputerState (idx + 1) (instr : acc)
+
+-- | Ensure molecule tags are always attached to blueprint-specific steps.
+attachMolecule :: MoleculeBlueprint -> InstructionMetadata -> InstructionMetadata
+attachMolecule blueprint meta = meta
+  { metadataProvenance = metadataProvenance meta
+      ++ [MoleculeTag (blueprintName blueprint) (blueprintHash blueprint)]
+  }
+
+registerBlueprint :: MoleculeBlueprint -> InstructionMetadata -> ChemputerM ()
+registerBlueprint blueprint meta =
+  emit (RegisterBlueprint blueprint) (attachMolecule blueprint meta)
+
+verifyBlueprint :: MoleculeBlueprint -> InstructionMetadata -> ChemputerM ()
+verifyBlueprint blueprint meta =
+  emit (VerifyMolecule blueprint (blueprintChecklist blueprint))
+       (attachMolecule blueprint meta)
+
+dose :: MoleculeBlueprint -> Double -> InstructionMetadata -> ChemputerM ()
+dose blueprint quantity meta =
+  emit (Dose blueprint quantity) (attachMolecule blueprint meta)
+
+adjustTemperature :: Double -> InstructionMetadata -> ChemputerM ()
+adjustTemperature value meta = emit (AdjustTemperature value) meta
+
+adjustPressure :: Double -> InstructionMetadata -> ChemputerM ()
+adjustPressure value meta = emit (AdjustPressure value) meta
+
+holdForRate :: Double -> InstructionMetadata -> ChemputerM ()
+holdForRate value meta = emit (HoldForRate value) meta
+
+recordProduct :: MoleculeBlueprint -> Double -> InstructionMetadata -> ChemputerM ()
+recordProduct blueprint quantity meta =
+  emit (RecordProduct blueprint quantity) (attachMolecule blueprint meta)
+
+emitNote :: Text -> InstructionMetadata -> ChemputerM ()
+emitNote note meta = emit (EmitNote note) meta
+
+-- | Compile a 'Reaction' into a deterministic instruction program.
+compileReaction :: Text -> Reaction -> ChemputerProgram ()
+compileReaction label reaction =
+  let script = do
+        let reactantBlueprints = zipWith (mkParticipant "reactant") [1 :: Int ..]
+                                 (reactants reaction)
+            productBlueprints  = zipWith (mkParticipant "product") [1 :: Int ..]
+                                 (products reaction)
+            reactionHash = fingerprintReaction label reactantBlueprints productBlueprints reaction
+            reactionTag  = ReactionTag label reactionHash
+
+        forM_ reactantBlueprints $ \(coeff, blueprint) -> do
+          let meta = withProvenance [reactionTag]
+                   $ withNotes ["Register reactant with stoichiometry " <> T.pack (show coeff)]
+                   $ emptyMetadata
+          registerBlueprint blueprint meta
+          verifyBlueprint blueprint meta
+
+        forM_ reactantBlueprints $ \(coeff, blueprint) -> do
+          let meta = withProvenance [reactionTag]
+                   $ withNotes ["Dose reactant at multiplier " <> T.pack (show coeff)]
+                   $ emptyMetadata
+          dose blueprint coeff meta
+
+        forM_ (conditions reaction) $ \case
+          TempCondition t ->
+            let meta = withProvenance [reactionTag]
+                     $ withNotes ["Set temperature"]
+                     $ emptyMetadata
+            in adjustTemperature t meta
+          PressureCondition p ->
+            let meta = withProvenance [reactionTag]
+                     $ withNotes ["Set pressure"]
+                     $ emptyMetadata
+            in adjustPressure p meta
+
+        let rateMeta = withProvenance [reactionTag]
+                     $ withNotes ["Hold reaction to satisfy rate constant"]
+                     $ emptyMetadata
+        holdForRate (rate reaction) rateMeta
+
+        forM_ productBlueprints $ \(coeff, blueprint) -> do
+          let meta = withProvenance [reactionTag]
+                   $ withNotes ["Record product yield multiplier " <> T.pack (show coeff)]
+                   $ emptyMetadata
+          recordProduct blueprint coeff meta
+
+        emitNote "Reaction program complete" (withProvenance [reactionTag] emptyMetadata)
+  in runChemputerProgram script
+  where
+    mkParticipant :: Text -> Int -> (Double, Molecule) -> (Double, MoleculeBlueprint)
+    mkParticipant role idx (coeff, molecule) =
+      let name = label <> " " <> role <> " " <> T.pack (show idx)
+      in (coeff, mkBlueprint name molecule)
+
+    fingerprintReaction :: Text
+                         -> [(Double, MoleculeBlueprint)]
+                         -> [(Double, MoleculeBlueprint)]
+                         -> Reaction
+                         -> Word64
+    fingerprintReaction name reactants' products' r =
+      hashBuilder $
+        BB.byteString (TE.encodeUtf8 name)
+        <> foldMap renderParticipant reactants'
+        <> BB.word8 0x7c
+        <> foldMap renderParticipant products'
+        <> BB.word8 0x2e
+        <> BB.doubleBE (rate r)
+        <> foldMap renderCondition (conditions r)
+
+    renderParticipant :: (Double, MoleculeBlueprint) -> BB.Builder
+    renderParticipant (coeff, blueprint) =
+      BB.doubleBE coeff <> BB.word64BE (blueprintHash blueprint)
+
+    renderCondition :: Condition -> BB.Builder
+    renderCondition (TempCondition t)    = BB.stringUtf8 "temp" <> BB.doubleBE t
+    renderCondition (PressureCondition p) = BB.stringUtf8 "press" <> BB.doubleBE p

--- a/src/InstructionsForBlockchain/Example.hs
+++ b/src/InstructionsForBlockchain/Example.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Self-contained walkthrough program that shows how to turn the
+-- hydrogen combustion reaction into a sequenced chemputer script.  The
+-- module exposes ready-to-use blueprints, the compiled program, and
+-- helper utilities for rendering the emitted instructions as human
+-- readable text.
+module InstructionsForBlockchain.Example
+  ( exampleReactionLabel
+  , hydrogenBlueprint
+  , oxygenBlueprint
+  , waterBlueprint
+  , combustionReaction
+  , combustionProgram
+  , combustionInstructions
+  , renderInstruction
+  , prettyCombustionScript
+  ) where
+
+import           Chem.Molecule (Molecule)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           Data.Word (Word64)
+
+import           InstructionsForBlockchain.ChemputerProgram
+                   ( ChemputerProgram(..)
+                   , ChemputerM
+                   , Instruction(..)
+                   , InstructionMetadata(..)
+                   , Operation(..)
+                   , ProvenanceTag(..)
+                   , adjustPressure
+                   , adjustTemperature
+                   , dose
+                   , emitNote
+                   , holdForRate
+                   , recordProduct
+                   , registerBlueprint
+                   , runChemputerProgram
+                   , verifyBlueprint
+                   , withNotes
+                   , withProvenance
+                   , emptyMetadata
+                   )
+import           InstructionsForBlockchain.Hash (hashBuilder, renderHash)
+import           InstructionsForBlockchain.MoleculeBlueprint
+                   ( MoleculeBlueprint(..)
+                   , VerificationChecklist(..)
+                   , mkBlueprint
+                   )
+import           Reaction (Condition(..), Reaction(..), exampleReaction)
+import           SampleMolecules (hydrogen, oxygen, water)
+
+-- | Human-readable label used for all provenance tags in this example.
+exampleReactionLabel :: Text
+exampleReactionLabel = "Hydrogen combustion example"
+
+-- | Convenience alias to reuse the existing reaction definition from
+-- the main library.
+combustionReaction :: Reaction
+combustionReaction = exampleReaction
+
+-- | Blueprint wrappers for the species involved in the combustion
+-- reaction.  These blueprints anchor the molecules with deterministic
+-- hashes that can be referenced from chemputer instructions or smart
+-- contracts.
+hydrogenBlueprint, oxygenBlueprint, waterBlueprint :: MoleculeBlueprint
+hydrogenBlueprint = blueprintFrom "Hydrogen (H₂)" hydrogen
+oxygenBlueprint   = blueprintFrom "Oxygen (O₂)" oxygen
+waterBlueprint    = blueprintFrom "Water (H₂O)" water
+
+-- | Compile the example reaction into a sequenced chemputer program.
+-- The script mirrors the individual steps a lab automation system
+-- would follow: register and verify each molecule, dose reactants,
+-- tune environmental conditions, wait for the rate target, and record
+-- the products.  A deterministic reaction tag ensures every emitted
+-- instruction carries reproducible provenance metadata.
+combustionProgram :: ChemputerProgram ()
+combustionProgram = runChemputerProgram $ do
+  let reactionTag = ReactionTag exampleReactionLabel (fingerprintReaction combustionReaction)
+      annotate :: Text -> InstructionMetadata
+      annotate msg = withProvenance [reactionTag]
+                   $ withNotes [msg]
+                   $ emptyMetadata
+
+  registerBlueprint hydrogenBlueprint (annotate "Register hydrogen feedstock blueprint")
+  verifyBlueprint hydrogenBlueprint (annotate "Validate hydrogen neighbour and charge map")
+
+  registerBlueprint oxygenBlueprint (annotate "Register oxygen oxidiser blueprint")
+  verifyBlueprint oxygenBlueprint (annotate "Validate oxygen neighbour and charge map")
+
+  registerBlueprint waterBlueprint (annotate "Register water condensate blueprint")
+  verifyBlueprint waterBlueprint (annotate "Validate water neighbour and charge map")
+
+  dose hydrogenBlueprint 2.0 (annotate "Dose hydrogen at 2.0 molar equivalents")
+  dose oxygenBlueprint 1.0 (annotate "Dose oxygen at 1.0 molar equivalents")
+
+  mapM_ (applyCondition annotate) (conditions combustionReaction)
+
+  holdForRate (rate combustionReaction)
+              (annotate ("Maintain reaction until rate constant "
+                        <> showDouble (rate combustionReaction)))
+
+  recordProduct waterBlueprint 2.0
+                (annotate "Record water yield at 2.0 molar equivalents")
+
+  emitNote "Hydrogen combustion example complete"
+           (withProvenance [reactionTag] emptyMetadata)
+
+-- | The ordered instruction log produced by 'combustionProgram'.
+combustionInstructions :: [Instruction]
+combustionInstructions = programInstructions combustionProgram
+
+-- | Render an instruction (including metadata) into a human readable
+-- paragraph.  This is handy for documentation, tutorials, or emitting
+-- artefacts alongside blockchain transactions.
+renderInstruction :: Instruction -> Text
+renderInstruction instruction =
+  T.intercalate "\n" $
+    headerLine :
+    map ("  " <>) detailLines ++
+    provenanceLines ++
+    noteLines
+  where
+    headerLine = T.pack (show (instructionIndex instruction))
+               <> ". "
+               <> heading
+    (heading, detailLines) = describeOperation (instructionOp instruction)
+    provenanceLines =
+      case metadataProvenance (instructionMeta instruction) of
+        []   -> []
+        tags -> ["  Provenance: " <> T.intercalate ", " (map renderTag tags)]
+    noteLines = map ("  Note: " <>) (metadataNotes (instructionMeta instruction))
+
+-- | Pretty printed multi-line summary of the entire program.
+prettyCombustionScript :: Text
+prettyCombustionScript = T.intercalate "\n\n" (map renderInstruction combustionInstructions)
+
+-- Internal helpers ---------------------------------------------------------
+
+blueprintFrom :: Text -> Molecule -> MoleculeBlueprint
+blueprintFrom = mkBlueprint
+
+showDouble :: Double -> Text
+showDouble = T.pack . show
+
+showInt :: Int -> Text
+showInt = T.pack . show
+
+applyCondition :: (Text -> InstructionMetadata) -> Condition -> ChemputerM ()
+applyCondition annotate (TempCondition t) =
+  adjustTemperature t (annotate ("Set reactor temperature to " <> showDouble t <> " K"))
+applyCondition annotate (PressureCondition p) =
+  adjustPressure p (annotate ("Regulate pressure to " <> showDouble p <> " bar"))
+
+fingerprintReaction :: Reaction -> Word64
+fingerprintReaction reaction =
+  hashBuilder $
+       BB.byteString (TE.encodeUtf8 exampleReactionLabel)
+    <> foldMap renderParticipant reactantBlueprints
+    <> BB.word8 0x7c
+    <> foldMap renderParticipant productBlueprints
+    <> BB.word8 0x2e
+    <> BB.doubleBE (rate reaction)
+    <> foldMap renderCondition (conditions reaction)
+  where
+    reactantBlueprints =
+      [ (coeff, blueprintFrom (participantName "reactant" idx) molecule)
+      | (idx, (coeff, molecule)) <- zip [1 :: Int ..] (reactants reaction)
+      ]
+    productBlueprints =
+      [ (coeff, blueprintFrom (participantName "product" idx) molecule)
+      | (idx, (coeff, molecule)) <- zip [1 :: Int ..] (products reaction)
+      ]
+
+participantName :: Text -> Int -> Text
+participantName role idx =
+  exampleReactionLabel <> " " <> role <> " " <> T.pack (show idx)
+
+renderParticipant :: (Double, MoleculeBlueprint) -> BB.Builder
+renderParticipant (coeff, blueprint) =
+     BB.doubleBE coeff
+  <> BB.word64BE (blueprintHash blueprint)
+
+renderCondition :: Condition -> BB.Builder
+renderCondition (TempCondition t)    = BB.stringUtf8 "temp" <> BB.doubleBE t
+renderCondition (PressureCondition p) = BB.stringUtf8 "press" <> BB.doubleBE p
+
+renderTag :: ProvenanceTag -> Text
+renderTag (MoleculeTag name hashValue) =
+  name <> " [" <> renderHash hashValue <> "]"
+renderTag (ReactionTag name hashValue) =
+  "reaction " <> name <> " [" <> renderHash hashValue <> "]"
+renderTag (ExternalReference ref) = ref
+
+-- | Break down each operation into a human readable heading and set of
+-- descriptive detail lines.
+describeOperation :: Operation -> (Text, [Text])
+describeOperation (RegisterBlueprint blueprint) =
+  ( "Register blueprint for " <> blueprintName blueprint
+  , [ "hash = " <> renderHash (blueprintHash blueprint)
+    , "payload bytes = " <> showInt (BS.length (blueprintBytes blueprint))
+    ]
+  )
+describeOperation (VerifyMolecule blueprint checklist) =
+  ( "Verify blueprint integrity for " <> blueprintName blueprint
+  , [ "neighbour entries = " <> showInt (mapSize (checklistNeighbours checklist))
+    , "charge entries = " <> showInt (mapSize (checklistCharges checklist))
+    ]
+  )
+describeOperation (Dose blueprint quantity) =
+  ( "Dose " <> blueprintName blueprint
+  , ["stoichiometric multiplier = " <> showDouble quantity]
+  )
+describeOperation (AdjustTemperature value) =
+  ( "Adjust temperature"
+  , ["target = " <> showDouble value <> " K"]
+  )
+describeOperation (AdjustPressure value) =
+  ( "Adjust pressure"
+  , ["target = " <> showDouble value <> " bar"]
+  )
+describeOperation (HoldForRate value) =
+  ( "Hold for rate constant"
+  , ["target = " <> showDouble value]
+  )
+describeOperation (RecordProduct blueprint quantity) =
+  ( "Record product " <> blueprintName blueprint
+  , ["expected multiplier = " <> showDouble quantity]
+  )
+describeOperation (EmitNote note) =
+  ( "Emit note"
+  , ["message = " <> note]
+  )
+
+mapSize :: Map k v -> Int
+mapSize = M.size

--- a/src/InstructionsForBlockchain/Hash.hs
+++ b/src/InstructionsForBlockchain/Hash.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Small hashing helpers tailored for reproducible on-chain payloads.
+-- The functions here avoid pulling in heavyweight crypto libraries while
+-- still providing deterministic digests that can be referenced from smart
+-- contracts.
+module InstructionsForBlockchain.Hash
+  ( fnv1a64
+  , hashBytes
+  , hashBinary
+  , hashBuilder
+  , renderHash
+  ) where
+
+import           Data.Bits (xor)
+import           Data.Binary (Binary, encode)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BL
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Word (Word64)
+import           Numeric (showHex)
+
+-- | FNV-1a constants for 64-bit hashing.
+fnvOffsetBasis64 :: Word64
+fnvOffsetBasis64 = 0xcbf29ce484222325
+
+fnvPrime64 :: Word64
+fnvPrime64 = 0x00000100000001B3
+
+-- | Reduce a 'ByteString' into an FNV-1a 64-bit hash.
+hashBytes :: ByteString -> Word64
+hashBytes = BS.foldl' step fnvOffsetBasis64
+  where
+    step h b = (h `xor` fromIntegral b) * fnvPrime64
+
+-- | Hash any value with a 'Binary' instance.
+hashBinary :: Binary a => a -> Word64
+hashBinary = hashBytes . BL.toStrict . encode
+
+-- | Hash the bytes emitted by a builder.  This is handy when the payload
+-- should mix structured numbers (Word64, Double, etc.).
+hashBuilder :: BB.Builder -> Word64
+hashBuilder = hashBytes . BL.toStrict . BB.toLazyByteString
+
+-- | Expose the raw FNV-1a implementation in case callers want to stream
+-- bytes in an incremental fashion.
+fnv1a64 :: ByteString -> Word64
+fnv1a64 = hashBytes
+
+-- | Render a hash as a hexadecimal 'Text' value.
+renderHash :: Word64 -> Text
+renderHash h = "0x" <> T.pack (showHex h "")

--- a/src/InstructionsForBlockchain/Minimal.hs
+++ b/src/InstructionsForBlockchain/Minimal.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Minimal blockchain instruction walkthrough that stays small enough to run
+-- from the executable's @main@ entry point.  The example registers a single
+-- water blueprint, doses it, records the product, and prints the resulting
+-- instruction log.
+module InstructionsForBlockchain.Minimal
+  ( minimalReactionLabel
+  , minimalReaction
+  , minimalProgram
+  , minimalInstructions
+  , renderMinimalInstruction
+  , prettyMinimalScript
+  , runMinimalDemo
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import           InstructionsForBlockchain.ChemputerProgram
+                   ( ChemputerProgram(..)
+                   , Instruction(..)
+                   , InstructionMetadata(..)
+                   , Operation(..)
+                   , ProvenanceTag(..)
+                   , compileReaction
+                   )
+import           InstructionsForBlockchain.Hash (renderHash)
+import           InstructionsForBlockchain.MoleculeBlueprint
+                   ( MoleculeBlueprint(..) )
+import           Reaction (Reaction(..))
+import           SampleMolecules (water)
+
+-- | Human-readable label shared by every instruction in the demonstration.
+minimalReactionLabel :: Text
+minimalReactionLabel = "Minimal water handling"
+
+-- | Single-step reaction that consumes and reproduces water.  No temperature or
+-- pressure tuning is required, which keeps the resulting instruction list short
+-- enough for a quick terminal demonstration.
+minimalReaction :: Reaction
+minimalReaction = Reaction
+  { reactants = [(1.0, water)]
+  , products = [(1.0, water)]
+  , conditions = []
+  , rate = 1.0
+  }
+
+-- | Program compiled from 'minimalReaction'.
+minimalProgram :: ChemputerProgram ()
+minimalProgram = compileReaction minimalReactionLabel minimalReaction
+
+-- | Ordered instructions emitted by 'minimalProgram'.
+minimalInstructions :: [Instruction]
+minimalInstructions = programInstructions minimalProgram
+
+-- | Render a single instruction into plain text with simple provenance and note
+-- output.  This keeps the terminal transcript compact while still exposing the
+-- hashes attached to each molecule and reaction step.
+renderMinimalInstruction :: Instruction -> Text
+renderMinimalInstruction instruction =
+  T.intercalate "\n" (headerLine : detailLines ++ provenanceLines ++ noteLines)
+  where
+    headerLine = T.pack (show (instructionIndex instruction))
+               <> ". "
+               <> describeOperation (instructionOp instruction)
+    detailLines = map ("  " <>) (operationDetails (instructionOp instruction))
+    meta = instructionMeta instruction
+    provenanceLines =
+      case metadataProvenance meta of
+        []   -> []
+        tags -> ["  provenance: " <> T.intercalate ", " (map renderTag tags)]
+    noteLines = map ("  note: " <>) (metadataNotes meta)
+
+-- | Render the entire instruction list separated by blank lines.
+prettyMinimalScript :: Text
+prettyMinimalScript = T.intercalate "\n\n" (map renderMinimalInstruction minimalInstructions)
+
+-- | Convenience helper used from the @main@ executable.  Prints a short banner
+-- followed by the pretty-printed instruction script.
+runMinimalDemo :: IO ()
+runMinimalDemo = do
+  putStrLn "--- Minimal chemputer instruction demo ---"
+  T.putStrLn prettyMinimalScript
+
+-- Internal helpers ---------------------------------------------------------
+
+describeOperation :: Operation -> Text
+describeOperation (RegisterBlueprint blueprint) =
+  "Register blueprint for " <> blueprintName blueprint
+describeOperation (VerifyMolecule blueprint _) =
+  "Verify blueprint integrity for " <> blueprintName blueprint
+describeOperation (Dose blueprint quantity) =
+  "Dose " <> blueprintName blueprint <> " at multiplier " <> showDouble quantity
+describeOperation (AdjustTemperature value) =
+  "Adjust temperature to " <> showDouble value <> " K"
+describeOperation (AdjustPressure value) =
+  "Adjust pressure to " <> showDouble value <> " bar"
+describeOperation (HoldForRate value) =
+  "Hold for rate constant " <> showDouble value
+describeOperation (RecordProduct blueprint quantity) =
+  "Record product " <> blueprintName blueprint <> " at multiplier " <> showDouble quantity
+describeOperation (EmitNote note) =
+  "Emit note: " <> note
+
+operationDetails :: Operation -> [Text]
+operationDetails (RegisterBlueprint blueprint) =
+  ["hash: " <> renderHash (blueprintHash blueprint)]
+operationDetails (VerifyMolecule _ _) = []
+operationDetails (Dose _ _) = []
+operationDetails (AdjustTemperature _) = []
+operationDetails (AdjustPressure _) = []
+operationDetails (HoldForRate _) = []
+operationDetails (RecordProduct blueprint _) =
+  ["hash: " <> renderHash (blueprintHash blueprint)]
+operationDetails (EmitNote _) = []
+
+renderTag :: ProvenanceTag -> Text
+renderTag (MoleculeTag name hashValue) =
+  name <> " [" <> renderHash hashValue <> "]"
+renderTag (ReactionTag name hashValue) =
+  name <> " [" <> renderHash hashValue <> "]"
+renderTag (ExternalReference ref) = ref
+
+showDouble :: Double -> Text
+showDouble = T.pack . show

--- a/src/InstructionsForBlockchain/MoleculeBlueprint.hs
+++ b/src/InstructionsForBlockchain/MoleculeBlueprint.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Canonical blueprints derived from 'Chem.Molecule.Molecule' values.  They
+-- capture the minimal metadata a chemputer or blockchain validator needs to
+-- confirm a molecule definition before executing instructions.
+module InstructionsForBlockchain.MoleculeBlueprint
+  ( MoleculeBlueprint(..)
+  , VerificationChecklist(..)
+  , mkBlueprint
+  , blueprintChecklist
+  , serialiseMolecule
+  , moleculeTag
+  ) where
+
+import           Chem.Dietz (AtomId)
+import           Chem.Molecule
+import           Data.Binary (encode)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BL
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Text (Text)
+import           Data.Word (Word64)
+
+import           InstructionsForBlockchain.Hash (hashBytes, renderHash)
+
+-- | Static description of a molecule with verification helpers.
+data MoleculeBlueprint = MoleculeBlueprint
+  { blueprintName       :: Text
+  , blueprintMolecule   :: Molecule
+  , blueprintHash       :: Word64
+  , blueprintBytes      :: ByteString
+  , blueprintNeighbours :: Map AtomId [AtomId]
+  , blueprintCharges    :: Map AtomId Int
+  } deriving (Eq, Show)
+
+-- | Checklist that a chemputer or smart contract can replay to confirm the
+-- uploaded molecule has not been tampered with.
+data VerificationChecklist = VerificationChecklist
+  { checklistNeighbours :: Map AtomId [AtomId]
+  , checklistCharges    :: Map AtomId Int
+  } deriving (Eq, Show)
+
+-- | Serialise a molecule using the existing 'Binary' instances for the
+-- constituent types.
+serialiseMolecule :: Molecule -> ByteString
+serialiseMolecule = BL.toStrict . encode
+
+-- | Build a blueprint from a molecule and a human-readable name.
+mkBlueprint :: Text -> Molecule -> MoleculeBlueprint
+mkBlueprint name molecule = MoleculeBlueprint
+  { blueprintName       = name
+  , blueprintMolecule   = molecule
+  , blueprintHash       = hashBytes bytes
+  , blueprintBytes      = bytes
+  , blueprintNeighbours = neighbourMap
+  , blueprintCharges    = chargeMap
+  }
+  where
+    bytes        = serialiseMolecule molecule
+    atomMap      = atoms molecule
+    neighbourMap = M.fromList
+      [ (atomId, neighborsSigma molecule atomId)
+      | (atomId, _) <- M.toList atomMap
+      ]
+    chargeMap    = M.fromList
+      [ (atomId, formalCharge atom)
+      | (atomId, atom) <- M.toList atomMap
+      ]
+
+-- | Generate the verification checklist associated with a blueprint.
+blueprintChecklist :: MoleculeBlueprint -> VerificationChecklist
+blueprintChecklist blueprint = VerificationChecklist
+  { checklistNeighbours = blueprintNeighbours blueprint
+  , checklistCharges    = blueprintCharges blueprint
+  }
+
+-- | Human-readable provenance tag combining the display name and hash.
+moleculeTag :: MoleculeBlueprint -> Text
+moleculeTag blueprint =
+  blueprintName blueprint <> " (" <> renderHash (blueprintHash blueprint) <> ")"


### PR DESCRIPTION
## Summary
- add a hydrogen combustion walkthrough module that registers blueprints, compiles instructions, and pretty-prints the chemputer log
- expose the example through the umbrella module and package metadata so downstream code can reuse it

## Testing
- not run (cabal unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_6903350145e88330aeb06bd6a4f1cbb9